### PR TITLE
Auto generate blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,11 @@ The **_[config.toml](./cmd/chainsimulator/config/config.toml)_** file:
         log-file-life-span-in-sec = 432000 # 5 days
         log-file-prefix = "chain-simulator"
         logs-path = "logs"
+    [config.blocks-generator]
+        # auto-generate-blocks specifies if the chain simulator should auto generate blocks
+        auto-generate-blocks = false
+        # block-time-in-milliseconds specifies the time between blocks generation in case auto-generate-blocks is enabled
+        block-time-in-milliseconds = 6000
 ```
 
 

--- a/cmd/chainsimulator/config/config.toml
+++ b/cmd/chainsimulator/config/config.toml
@@ -18,12 +18,13 @@
         mx-chain-go-repo = "https://github.com/multiversx/mx-chain-go"
         # mx-chain-proxy-go-repo will be used to fetch the proxy configs folder
         mx-chain-proxy-go-repo = "https://github.com/multiversx/mx-chain-proxy-go"
-        # auto-generate-blocks specifies if the chain simulator should auto generate blocks
-        auto-generate-blocks = false
-        #  block-time-in-milliseconds specifies the time between blocks generation in case auto-generate-blocks is enabled
-        block-time-in-milliseconds = 6000
     [config.logs]
         log-file-life-span-in-mb = 1024 # 1GB
         log-file-life-span-in-sec = 432000 # 5 days
         log-file-prefix = "chain-simulator"
         logs-path = "logs"
+    [config.blocks-generator]
+        # auto-generate-blocks specifies if the chain simulator should auto generate blocks
+        auto-generate-blocks = false
+        #  block-time-in-milliseconds specifies the time between blocks generation in case auto-generate-blocks is enabled
+        block-time-in-milliseconds = 6000

--- a/cmd/chainsimulator/config/config.toml
+++ b/cmd/chainsimulator/config/config.toml
@@ -26,5 +26,5 @@
     [config.blocks-generator]
         # auto-generate-blocks specifies if the chain simulator should auto generate blocks
         auto-generate-blocks = false
-        #  block-time-in-milliseconds specifies the time between blocks generation in case auto-generate-blocks is enabled
+        # block-time-in-milliseconds specifies the time between blocks generation in case auto-generate-blocks is enabled
         block-time-in-milliseconds = 6000

--- a/cmd/chainsimulator/config/config.toml
+++ b/cmd/chainsimulator/config/config.toml
@@ -18,6 +18,10 @@
         mx-chain-go-repo = "https://github.com/multiversx/mx-chain-go"
         # mx-chain-proxy-go-repo will be used to fetch the proxy configs folder
         mx-chain-proxy-go-repo = "https://github.com/multiversx/mx-chain-proxy-go"
+        # auto-generate-blocks specifies if the chain simulator should auto generate blocks
+        auto-generate-blocks = false
+        #  block-time-in-milliseconds specifies the time between blocks generation in case auto-generate-blocks is enabled
+        block-time-in-milliseconds = 6000
     [config.logs]
         log-file-life-span-in-mb = 1024 # 1GB
         log-file-life-span-in-sec = 432000 # 5 days

--- a/cmd/chainsimulator/flags.go
+++ b/cmd/chainsimulator/flags.go
@@ -137,10 +137,10 @@ func applyFlags(ctx *cli.Context, cfg *config.Config) {
 	}
 
 	if ctx.IsSet(autoGenerateBlocks.Name) {
-		cfg.Config.Simulator.AutoGenerateBlocks = ctx.GlobalBool(autoGenerateBlocks.Name)
+		cfg.Config.BlocksGenerator.AutoGenerateBlocks = ctx.GlobalBool(autoGenerateBlocks.Name)
 	}
 
 	if ctx.IsSet(blockTimeInMs.Name) {
-		cfg.Config.Simulator.BlockTimeInMs = ctx.GlobalUint64(blockTimeInMs.Name)
+		cfg.Config.BlocksGenerator.BlockTimeInMs = ctx.GlobalUint64(blockTimeInMs.Name)
 	}
 }

--- a/cmd/chainsimulator/flags.go
+++ b/cmd/chainsimulator/flags.go
@@ -96,6 +96,15 @@ var (
 		Usage: "This flag is used to specify the initial epoch when chain simulator will start",
 		Value: 0,
 	}
+	autoGenerateBlocks = cli.BoolFlag{
+		Name:  "auto-generate-blocks",
+		Usage: "Boolean option to specify that blocks should be generated automatically, after a given period of time",
+	}
+	blockTimeInMs = cli.Uint64Flag{
+		Name:  "block-time-in-milliseconds",
+		Usage: "The time between blocks generations, when autoGenerateBlocks flag is true",
+		Value: 6000,
+	}
 )
 
 func applyFlags(ctx *cli.Context, cfg *config.Config) {
@@ -125,5 +134,13 @@ func applyFlags(ctx *cli.Context, cfg *config.Config) {
 
 	if ctx.IsSet(initialEpoch.Name) {
 		cfg.Config.Simulator.InitialEpoch = uint32(ctx.GlobalUint(initialEpoch.Name))
+	}
+
+	if ctx.IsSet(autoGenerateBlocks.Name) {
+		cfg.Config.Simulator.AutoGenerateBlocks = ctx.GlobalBool(autoGenerateBlocks.Name)
+	}
+
+	if ctx.IsSet(blockTimeInMs.Name) {
+		cfg.Config.Simulator.BlockTimeInMs = ctx.GlobalUint64(blockTimeInMs.Name)
 	}
 }

--- a/cmd/chainsimulator/main.go
+++ b/cmd/chainsimulator/main.go
@@ -174,9 +174,7 @@ func startChainSimulator(ctx *cli.Context) error {
 		return err
 	}
 
-	cancelBlockAutoGeneration := func() {}
-	var ctxBlocksGeneration context.Context
-	ctxBlocksGeneration, cancelBlockAutoGeneration = context.WithCancel(context.Background())
+	ctxBlocksGeneration, cancelBlockAutoGeneration := context.WithCancel(context.Background())
 	defer cancelBlockAutoGeneration()
 
 	if cfg.Config.Simulator.AutoGenerateBlocks {

--- a/config/config.go
+++ b/config/config.go
@@ -4,17 +4,15 @@ package config
 type Config struct {
 	Config struct {
 		Simulator struct {
-			ServerPort         int    `toml:"server-port"`
-			NumOfShards        int    `toml:"num-of-shards"`
-			RoundsPerEpoch     int    `toml:"rounds-per-epoch"`
-			RoundDurationInMs  int    `toml:"round-duration-in-milliseconds"`
-			InitialRound       int64  `toml:"initial-round"`
-			InitialNonce       uint64 `toml:"initial-nonce"`
-			InitialEpoch       uint32 `toml:"initial-epoch"`
-			MxChainRepo        string `toml:"mx-chain-go-repo"`
-			MxProxyRepo        string `toml:"mx-chain-proxy-go-repo"`
-			AutoGenerateBlocks bool   `toml:"auto-generate-blocks"`
-			BlockTimeInMs      uint64 `toml:"block-time-in-milliseconds"`
+			ServerPort        int    `toml:"server-port"`
+			NumOfShards       int    `toml:"num-of-shards"`
+			RoundsPerEpoch    int    `toml:"rounds-per-epoch"`
+			RoundDurationInMs int    `toml:"round-duration-in-milliseconds"`
+			InitialRound      int64  `toml:"initial-round"`
+			InitialNonce      uint64 `toml:"initial-nonce"`
+			InitialEpoch      uint32 `toml:"initial-epoch"`
+			MxChainRepo       string `toml:"mx-chain-go-repo"`
+			MxProxyRepo       string `toml:"mx-chain-proxy-go-repo"`
 		} `toml:"simulator"`
 		Logs struct {
 			LogFileLifeSpanInMB  int    `toml:"log-file-life-span-in-mb"`
@@ -22,5 +20,12 @@ type Config struct {
 			LogFilePrefix        string `toml:"log-file-prefix"`
 			LogsPath             string `toml:"logs-path"`
 		} `toml:"logs"`
+		BlocksGenerator BlocksGeneratorConfig `toml:"blocks-generator"`
 	} `toml:"config"`
+}
+
+// BlocksGeneratorConfig defined the configuration for the blocks generator
+type BlocksGeneratorConfig struct {
+	AutoGenerateBlocks bool   `toml:"auto-generate-blocks"`
+	BlockTimeInMs      uint64 `toml:"block-time-in-milliseconds"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -4,15 +4,17 @@ package config
 type Config struct {
 	Config struct {
 		Simulator struct {
-			ServerPort        int    `toml:"server-port"`
-			NumOfShards       int    `toml:"num-of-shards"`
-			RoundsPerEpoch    int    `toml:"rounds-per-epoch"`
-			RoundDurationInMs int    `toml:"round-duration-in-milliseconds"`
-			InitialRound      int64  `toml:"initial-round"`
-			InitialNonce      uint64 `toml:"initial-nonce"`
-			InitialEpoch      uint32 `toml:"initial-epoch"`
-			MxChainRepo       string `toml:"mx-chain-go-repo"`
-			MxProxyRepo       string `toml:"mx-chain-proxy-go-repo"`
+			ServerPort         int    `toml:"server-port"`
+			NumOfShards        int    `toml:"num-of-shards"`
+			RoundsPerEpoch     int    `toml:"rounds-per-epoch"`
+			RoundDurationInMs  int    `toml:"round-duration-in-milliseconds"`
+			InitialRound       int64  `toml:"initial-round"`
+			InitialNonce       uint64 `toml:"initial-nonce"`
+			InitialEpoch       uint32 `toml:"initial-epoch"`
+			MxChainRepo        string `toml:"mx-chain-go-repo"`
+			MxProxyRepo        string `toml:"mx-chain-proxy-go-repo"`
+			AutoGenerateBlocks bool   `toml:"auto-generate-blocks"`
+			BlockTimeInMs      uint64 `toml:"block-time-in-milliseconds"`
 		} `toml:"simulator"`
 		Logs struct {
 			LogFileLifeSpanInMB  int    `toml:"log-file-life-span-in-mb"`

--- a/pkg/factory/blocksGeneratorFactory.go
+++ b/pkg/factory/blocksGeneratorFactory.go
@@ -1,0 +1,19 @@
+package factory
+
+import (
+	"github.com/multiversx/mx-chain-simulator-go/config"
+	"github.com/multiversx/mx-chain-simulator-go/pkg/process"
+	"github.com/multiversx/mx-chain-simulator-go/pkg/process/disabled"
+)
+
+// CreateBlocksGenerator creates a new instance of block generator
+func CreateBlocksGenerator(simulator process.SimulatorHandler, config config.BlocksGeneratorConfig) (process.BlocksGenerator, error) {
+	if config.AutoGenerateBlocks {
+		return process.NewBlocksGenerator(process.ArgBlocksGenerator{
+			Simulator:     simulator,
+			BlockTimeInMs: config.BlockTimeInMs,
+		})
+	}
+
+	return disabled.NewBlocksGenerator(), nil
+}

--- a/pkg/factory/blocksGeneratorFactory_test.go
+++ b/pkg/factory/blocksGeneratorFactory_test.go
@@ -1,0 +1,35 @@
+package factory
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/multiversx/mx-chain-simulator-go/config"
+	"github.com/multiversx/mx-chain-simulator-go/testscommon"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateBlocksGenerator(t *testing.T) {
+	t.Parallel()
+
+	t.Run("disabled auto generate should return disabled component", func(t *testing.T) {
+		t.Parallel()
+
+		generator, err := CreateBlocksGenerator(&testscommon.SimulatorHandlerMock{}, config.BlocksGeneratorConfig{})
+		require.NoError(t, err)
+		require.NotNil(t, generator)
+		require.Equal(t, "*disabled.blocksGenerator", fmt.Sprintf("%T", generator))
+	})
+	t.Run("enabled auto generate should return disabled component", func(t *testing.T) {
+		t.Parallel()
+
+		generator, err := CreateBlocksGenerator(&testscommon.SimulatorHandlerMock{}, config.BlocksGeneratorConfig{
+			AutoGenerateBlocks: true,
+			BlockTimeInMs:      100,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, generator)
+		require.Equal(t, "*process.blocksGenerator", fmt.Sprintf("%T", generator))
+		generator.Close() // close the internal goroutine
+	})
+}

--- a/pkg/process/blocksGenerator.go
+++ b/pkg/process/blocksGenerator.go
@@ -1,0 +1,69 @@
+package process
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/multiversx/mx-chain-core-go/core/check"
+	logger "github.com/multiversx/mx-chain-logger-go"
+)
+
+var log = logger.GetOrCreate("process")
+
+const minBlockTimeInMs = 1
+
+// ArgBlocksGenerator defines the dto used to create a new instance of blocksGenerator
+type ArgBlocksGenerator struct {
+	Simulator     SimulatorHandler
+	BlockTimeInMs uint64
+}
+type blocksGenerator struct {
+	cancel    func()
+	simulator SimulatorHandler
+	blockTime time.Duration
+}
+
+// NewBlocksGenerator returns a new instance of blocksGenerator
+func NewBlocksGenerator(args ArgBlocksGenerator) (*blocksGenerator, error) {
+	if check.IfNil(args.Simulator) {
+		return nil, errNilChainSimulator
+	}
+	if args.BlockTimeInMs < minBlockTimeInMs {
+		return nil, fmt.Errorf("%w for BlockTimeInMs, received %d, min expected %d", errInvalidValue, args.BlockTimeInMs, minBlockTimeInMs)
+	}
+	instance := &blocksGenerator{
+		simulator: args.Simulator,
+		blockTime: time.Duration(args.BlockTimeInMs) * time.Millisecond,
+	}
+	var ctx context.Context
+	ctx, instance.cancel = context.WithCancel(context.Background())
+
+	go instance.generateBlocks(ctx)
+
+	return instance, nil
+}
+
+func (generator *blocksGenerator) generateBlocks(ctx context.Context) {
+	log.Info("Running in auto-generate-blocks mode, starting the go routine...")
+
+	timerBlock := time.NewTimer(generator.blockTime)
+	for {
+		timerBlock.Reset(generator.blockTime)
+		select {
+		case <-timerBlock.C:
+			err := generator.simulator.GenerateBlocks(1)
+			if err != nil {
+				log.Error("failed to generate block", "error", err.Error())
+			}
+		case <-ctx.Done():
+			log.Debug("closing the automatic blocks generation goroutine...")
+			return
+		}
+	}
+}
+
+// Close closes the internal goroutine
+func (generator *blocksGenerator) Close() {
+	generator.cancel()
+}

--- a/pkg/process/blocksGenerator.go
+++ b/pkg/process/blocksGenerator.go
@@ -47,11 +47,10 @@ func NewBlocksGenerator(args ArgBlocksGenerator) (*blocksGenerator, error) {
 func (generator *blocksGenerator) generateBlocks(ctx context.Context) {
 	log.Info("Running in auto-generate-blocks mode, starting the go routine...")
 
-	timerBlock := time.NewTimer(generator.blockTime)
+	blockTicker := time.NewTicker(generator.blockTime)
 	for {
-		timerBlock.Reset(generator.blockTime)
 		select {
-		case <-timerBlock.C:
+		case <-blockTicker.C:
 			err := generator.simulator.GenerateBlocks(1)
 			if err != nil {
 				log.Error("failed to generate block", "error", err.Error())

--- a/pkg/process/blocksGenerator_test.go
+++ b/pkg/process/blocksGenerator_test.go
@@ -1,0 +1,77 @@
+package process
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/multiversx/mx-chain-simulator-go/testscommon"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBlocksGenerator(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil simulator should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := ArgBlocksGenerator{
+			Simulator:     nil,
+			BlockTimeInMs: 0,
+		}
+		generator, err := NewBlocksGenerator(args)
+		require.Equal(t, errNilChainSimulator, err)
+		require.Nil(t, generator)
+	})
+	t.Run("invalid block time should error", func(t *testing.T) {
+		t.Parallel()
+
+		args := ArgBlocksGenerator{
+			Simulator:     &testscommon.SimulatorHandlerMock{},
+			BlockTimeInMs: 0,
+		}
+		generator, err := NewBlocksGenerator(args)
+		require.True(t, errors.Is(err, errInvalidValue))
+		require.Nil(t, generator)
+	})
+	t.Run("should work", func(t *testing.T) {
+		t.Parallel()
+
+		providedBlockTime := uint64(100)
+		chanDone := make(chan struct{})
+		cnt := uint32(0)
+		args := ArgBlocksGenerator{
+			Simulator: &testscommon.SimulatorHandlerMock{
+				GenerateBlocksCalled: func(numOfBlocks int) error {
+					require.Equal(t, 1, numOfBlocks)
+
+					atomic.AddUint32(&cnt, 1)
+					if atomic.LoadUint32(&cnt) == 1 {
+						return errors.New("expected error") // for coverage only
+					}
+
+					chanDone <- struct{}{}
+
+					return nil
+				},
+			},
+			BlockTimeInMs: providedBlockTime,
+		}
+		generator, err := NewBlocksGenerator(args)
+		require.NoError(t, err)
+		require.NotNil(t, generator)
+
+		for {
+			select {
+			case <-chanDone:
+				generator.Close()
+				return
+			case <-time.After(time.Duration(providedBlockTime*3) * time.Millisecond):
+				generator.Close()
+				require.Fail(t, "timeout")
+				return
+			}
+		}
+	})
+}

--- a/pkg/process/disabled/blocksGenerator.go
+++ b/pkg/process/disabled/blocksGenerator.go
@@ -1,0 +1,13 @@
+package disabled
+
+type blocksGenerator struct {
+}
+
+// NewBlocksGenerator returns a new instance of disabled blocks generator
+func NewBlocksGenerator() *blocksGenerator {
+	return &blocksGenerator{}
+}
+
+// Close does nothing as it is disabled
+func (generator *blocksGenerator) Close() {
+}

--- a/pkg/process/disabled/blocksGenerator_test.go
+++ b/pkg/process/disabled/blocksGenerator_test.go
@@ -1,0 +1,15 @@
+package disabled
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlocksGenerator(t *testing.T) {
+	t.Parallel()
+
+	generator := NewBlocksGenerator()
+	require.NotNil(t, generator)
+	generator.Close()
+}

--- a/pkg/process/errors.go
+++ b/pkg/process/errors.go
@@ -1,0 +1,8 @@
+package process
+
+import "errors"
+
+var (
+	errNilChainSimulator = errors.New("nil chain simulator")
+	errInvalidValue      = errors.New("invalid value")
+)

--- a/pkg/process/interface.go
+++ b/pkg/process/interface.go
@@ -1,0 +1,12 @@
+package process
+
+// SimulatorHandler defines what a simulator handler should be able to do
+type SimulatorHandler interface {
+	GenerateBlocks(numOfBlocks int) error
+	IsInterfaceNil() bool
+}
+
+// BlocksGenerator defines a component able to generate blocks
+type BlocksGenerator interface {
+	Close()
+}

--- a/testscommon/simulatorHandlerMock.go
+++ b/testscommon/simulatorHandlerMock.go
@@ -1,0 +1,57 @@
+package testscommon
+
+import "github.com/multiversx/mx-chain-go/node/chainSimulator/dtos"
+
+// SimulatorHandlerMock -
+type SimulatorHandlerMock struct {
+	GetInitialWalletKeysCalled  func() *dtos.InitialWalletKeys
+	GenerateBlocksCalled        func(numOfBlocks int) error
+	SetKeyValueForAddressCalled func(address string, keyValueMap map[string]string) error
+	SetStateMultipleCalled      func(stateSlice []*dtos.AddressState) error
+	AddValidatorKeysCalled      func(validatorsPrivateKeys [][]byte) error
+}
+
+// GetInitialWalletKeys -
+func (mock *SimulatorHandlerMock) GetInitialWalletKeys() *dtos.InitialWalletKeys {
+	if mock.GetInitialWalletKeysCalled != nil {
+		return mock.GetInitialWalletKeysCalled()
+	}
+	return nil
+}
+
+// GenerateBlocks -
+func (mock *SimulatorHandlerMock) GenerateBlocks(numOfBlocks int) error {
+	if mock.GenerateBlocksCalled != nil {
+		return mock.GenerateBlocksCalled(numOfBlocks)
+	}
+	return nil
+}
+
+// SetKeyValueForAddress -
+func (mock *SimulatorHandlerMock) SetKeyValueForAddress(address string, keyValueMap map[string]string) error {
+	if mock.SetKeyValueForAddressCalled != nil {
+		return mock.SetKeyValueForAddressCalled(address, keyValueMap)
+	}
+	return nil
+}
+
+// SetStateMultiple -
+func (mock *SimulatorHandlerMock) SetStateMultiple(stateSlice []*dtos.AddressState) error {
+	if mock.SetStateMultipleCalled != nil {
+		return mock.SetStateMultipleCalled(stateSlice)
+	}
+	return nil
+}
+
+// AddValidatorKeys -
+func (mock *SimulatorHandlerMock) AddValidatorKeys(validatorsPrivateKeys [][]byte) error {
+	if mock.AddValidatorKeysCalled != nil {
+		return mock.AddValidatorKeysCalled(validatorsPrivateKeys)
+	}
+	return nil
+}
+
+// IsInterfaceNil -
+func (mock *SimulatorHandlerMock) IsInterfaceNil() bool {
+	return mock == nil
+}


### PR DESCRIPTION
Implemented the auto generation of the blocks feature, which can be enabled via `auto-generate-blocks` flag. With this flag on, the binary will generate blocks at the speed of the provided flag `block-time-in-milliseconds`