### PR TITLE
Fix `set state` endpoint and update Readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,5 @@ COPY --from=builder "/lib/libwasmer_linux_amd64.so" "/lib/libwasmer_linux_amd64.
 COPY --from=builder "/lib/libvmexeccapi.so" "/lib/libvmexeccapi.so"
 
 ENTRYPOINT ["./chainsimulator"]
-CMD ["--log-level", "*:DEBUG"]
 
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,15 @@ The **_[config.toml](./cmd/chainsimulator/config/config.toml)_** file:
         block-time-in-milliseconds = 6000
 ```
 
+### Build docker image
+```
+DOCKER_BUILDKIT=1 docker build -t chainsimulator:latest .
+```
+
+### Run with docker
+```
+docker run -p 8085:8085 chainsimulator:latest --log-level *:DEBUG
+```
 
 ## Contribution
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/multiversx/mx-chain-core-go v1.2.19-0.20240129082057-a76d0c995cf2
-	github.com/multiversx/mx-chain-go v1.7.3-0.20240221154137-aa16de3cd5e5
+	github.com/multiversx/mx-chain-go v1.7.3-0.20240227085446-81d81e932f9c
 	github.com/multiversx/mx-chain-logger-go v1.0.14-0.20240129144507-d00e967c890c
 	github.com/multiversx/mx-chain-proxy-go v1.1.41
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -401,8 +401,8 @@ github.com/multiversx/mx-chain-crypto-go v1.2.10-0.20231206065052-38843c1f1479 h
 github.com/multiversx/mx-chain-crypto-go v1.2.10-0.20231206065052-38843c1f1479/go.mod h1:Ap6p7QZFtwPlb++OvCG+85BfuZ+bLP/JtQp6EwjWJsI=
 github.com/multiversx/mx-chain-es-indexer-go v1.4.19-0.20240129150813-a772c480d33a h1:mOMUhbsjTq7n5oAv4KkVnL67ngS0+wkqmkiv1XJfBIY=
 github.com/multiversx/mx-chain-es-indexer-go v1.4.19-0.20240129150813-a772c480d33a/go.mod h1:3aSGRJNvfUuPQkZUGHWuF11rPPxphsKGuAuIB+eD3is=
-github.com/multiversx/mx-chain-go v1.7.3-0.20240221154137-aa16de3cd5e5 h1:Yp/2/WwmVMkukBm8bd9ABZY/ZRYw/Qp2j2yvCu5ib/0=
-github.com/multiversx/mx-chain-go v1.7.3-0.20240221154137-aa16de3cd5e5/go.mod h1:lig6YN9ltTpb6gKhu1kXwiOJfO+WEzYTrjggocyxwkU=
+github.com/multiversx/mx-chain-go v1.7.3-0.20240227085446-81d81e932f9c h1:E4PPlRNAU6y1/91i1lz4rru5Ze1J+VlQRNkwWZ1SaKY=
+github.com/multiversx/mx-chain-go v1.7.3-0.20240227085446-81d81e932f9c/go.mod h1:lig6YN9ltTpb6gKhu1kXwiOJfO+WEzYTrjggocyxwkU=
 github.com/multiversx/mx-chain-logger-go v1.0.14-0.20240129144507-d00e967c890c h1:QIUOn8FgNRa5cir4BCWHZi/Qcr6Gg0eGNhns4+jy6+k=
 github.com/multiversx/mx-chain-logger-go v1.0.14-0.20240129144507-d00e967c890c/go.mod h1:fH/fR/GEBsDjPkBoZDVJMoYo2HhlA7++DP6QfITJ1N8=
 github.com/multiversx/mx-chain-proxy-go v1.1.41 h1:u5LTek2keNvd25jrOmHLp0N4AFwYFImBnrs+GR7IGRY=


### PR DESCRIPTION
- Fixed the `set-state` endpoint
- Updated the Readme file with information about how to run the `chainsimulator` with Docker
- Changed the version of `mx-chain-go` module