### PR TITLE
Proxy port and print

### DIFF
--- a/cmd/chainsimulator/main.go
+++ b/cmd/chainsimulator/main.go
@@ -26,7 +26,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-const timeToAllowProxyToStart = time.Second * 2
+const timeToAllowProxyToStart = time.Millisecond * 10
 
 var (
 	log          = logger.GetOrCreate("chainsimulator")

--- a/cmd/chainsimulator/main.go
+++ b/cmd/chainsimulator/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime/debug"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -24,6 +25,8 @@ import (
 	"github.com/multiversx/mx-chain-simulator-go/pkg/proxy/creator"
 	"github.com/urfave/cli"
 )
+
+const timeToAllowProxyToStart = time.Second * 2
 
 var (
 	log          = logger.GetOrCreate("chainsimulator")
@@ -135,8 +138,21 @@ func startChainSimulator(ctx *cli.Context) error {
 		return errors.New("invalid value for the number of validators for metachain")
 	}
 
+	localRestApiInterface := "localhost"
+	apiConfigurator := api.NewFreePortAPIConfigurator(localRestApiInterface)
+	proxyPort := cfg.Config.Simulator.ServerPort
+	proxyURL := fmt.Sprintf(fmt.Sprintf("%s:%d", localRestApiInterface, proxyPort))
+	if proxyPort == 0 {
+		proxyURL = apiConfigurator.RestApiInterface(0)
+		portString := proxyURL[len(localRestApiInterface)+1:]
+		port, errConvert := strconv.Atoi(portString)
+		if errConvert != nil {
+			return fmt.Errorf("internal error while searching a free port for the proxy component: %w", errConvert)
+		}
+		proxyPort = port
+	}
+
 	startTimeUnix := ctx.GlobalInt64(startTime.Name)
-	apiConfigurator := api.NewFreePortAPIConfigurator("localhost")
 	argsChainSimulator := chainSimulator.ArgsChainSimulator{
 		BypassTxSignatureCheck: bypassTxsSignature,
 		TempDir:                os.TempDir(),
@@ -166,7 +182,7 @@ func startChainSimulator(ctx *cli.Context) error {
 	outputProxyConfigs, err := configs.CreateProxyConfigs(configs.ArgsProxyConfigs{
 		TemDir:            os.TempDir(),
 		PathToProxyConfig: proxyConfigs,
-		ServerPort:        cfg.Config.Simulator.ServerPort,
+		ServerPort:        proxyPort,
 		RestApiInterfaces: restApiInterfaces,
 		InitialWallets:    simulator.GetInitialWalletKeys().ShardWallets,
 	})
@@ -202,6 +218,9 @@ func startChainSimulator(ctx *cli.Context) error {
 	}
 
 	proxyInstance.Start()
+
+	time.Sleep(timeToAllowProxyToStart)
+	log.Info(fmt.Sprintf("chain simulator's is accessible through the URL %s", proxyURL))
 
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, syscall.SIGINT, syscall.SIGTERM)


### PR DESCRIPTION
- made the proxy start on a random port
- print the URL for the proxy after the chain simulator is up and running