### PR TITLE
Simulator observers endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ This endpoint returns the initial wallets (address and private key hex encoded).
 
 ### `GET /simulator/observers`
 
-This endpoint returns the initial wallets (address and private key hex encoded).
+This endpoint returns information about the observers that are behind chain simulator
 
 ##### Request
 - **Method:** GET

--- a/README.md
+++ b/README.md
@@ -107,6 +107,36 @@ This endpoint returns the initial wallets (address and private key hex encoded).
 }
 ```
 
+### `GET /simulator/observers`
+
+This endpoint returns the initial wallets (address and private key hex encoded).
+
+##### Request
+- **Method:** GET
+- **Path:** `/simulator/observers`
+
+##### Response
+- **Status Codes:**
+  - `200 OK`: Observers information retrieved successfully.
+
+#### Response Body (Example)
+```
+{
+  "data": {
+    "0": {
+       "api-port": 52747
+    },
+    "1": {
+       "api-port": 52749
+    }
+     // ... additional observers entries
+  },
+  "error": "",
+  "code": "successful"
+}
+```
+
+
 
 ### `POST /simulator/address/:address/set-state`
 

--- a/examples/setState/code-metadata.py
+++ b/examples/setState/code-metadata.py
@@ -4,7 +4,7 @@ from multiversx_sdk_network_providers import ProxyNetworkProvider
 
 SIMULATOR_URL = "http://localhost:8085"
 GENERATE_BLOCKS_URL = f"{SIMULATOR_URL}/simulator/generate-blocks"
-SET_STATE_URL = f"{SIMULATOR_URL}/simulator/set-state"
+SET_STATE_URL = f"{SIMULATOR_URL}/simulator/set-state-overwrite"
 ADDRESS_URL = f"{SIMULATOR_URL}/address/"
 
 

--- a/pkg/dtos/observers.go
+++ b/pkg/dtos/observers.go
@@ -1,0 +1,5 @@
+package dtos
+
+type ObserverInfo struct {
+	APIPort int `json:"api-port"`
+}

--- a/pkg/dtos/observers.go
+++ b/pkg/dtos/observers.go
@@ -1,5 +1,6 @@
 package dtos
 
+// ObserverInfo is the dto that contains information about an observer
 type ObserverInfo struct {
 	APIPort int `json:"api-port"`
 }

--- a/pkg/facade/interface.go
+++ b/pkg/facade/interface.go
@@ -12,5 +12,6 @@ type SimulatorHandler interface {
 	AddValidatorKeys(validatorsPrivateKeys [][]byte) error
 	GenerateBlocksUntilEpochIsReached(targetEpoch int32) error
 	ForceResetValidatorStatisticsCache() error
+	GetRestAPIInterfaces() map[uint32]string
 	IsInterfaceNil() bool
 }

--- a/pkg/facade/simulatorFacade.go
+++ b/pkg/facade/simulatorFacade.go
@@ -54,15 +54,13 @@ func (sf *simulatorFacade) SetStateMultiple(stateSlice []*dtos.AddressState) err
 
 // SetStateMultipleOverwrite will set the entire state for the provided address and cleanup the old state of the provided addresses
 func (sf *simulatorFacade) SetStateMultipleOverwrite(stateSlice []*dtos.AddressState) error {
-	accounts := make([]string, 0, len(stateSlice))
 	for _, state := range stateSlice {
-		accounts = append(accounts, state.Address)
-	}
-
-	err := sf.simulator.RemoveAccounts(accounts)
-	shouldReturnErr := err != nil && !strings.Contains(err.Error(), errMsgAccountNotFound)
-	if shouldReturnErr {
-		return err
+		// TODO MX-15414
+		err := sf.simulator.RemoveAccounts([]string{state.Address})
+		shouldReturnErr := err != nil && !strings.Contains(err.Error(), errMsgAccountNotFound)
+		if shouldReturnErr {
+			return err
+		}
 	}
 
 	return sf.simulator.SetStateMultiple(stateSlice)

--- a/pkg/facade/simulatorFacade.go
+++ b/pkg/facade/simulatorFacade.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-go/node/chainSimulator/dtos"
@@ -91,6 +93,30 @@ func (sf *simulatorFacade) GenerateBlocksUntilEpochIsReached(targetEpoch int32) 
 // ForceUpdateValidatorStatistics will force the reset of the cache used for the validators statistics endpoint
 func (sf *simulatorFacade) ForceUpdateValidatorStatistics() error {
 	return sf.simulator.ForceResetValidatorStatisticsCache()
+}
+
+// GetObserversInfo will return information about the observers
+func (sf *simulatorFacade) GetObserversInfo() (map[uint32]*dtoc.ObserverInfo, error) {
+	restApiInterface := sf.simulator.GetRestAPIInterfaces()
+
+	response := make(map[uint32]*dtoc.ObserverInfo)
+	for shardID, apiInterface := range restApiInterface {
+		split := strings.Split(apiInterface, ":")
+		if len(split) != 2 {
+			return nil, fmt.Errorf("cannot extrac port for shard ID=%d", shardID)
+		}
+
+		port, err := strconv.Atoi(split[1])
+		if err != nil {
+			return nil, fmt.Errorf("cannot cast port string to int for shard ID=%d", shardID)
+		}
+
+		response[shardID] = &dtoc.ObserverInfo{
+			APIPort: port,
+		}
+	}
+
+	return response, nil
 }
 
 // IsInterfaceNil returns true if there is no value under the interface

--- a/pkg/facade/simulatorFacade.go
+++ b/pkg/facade/simulatorFacade.go
@@ -12,6 +12,8 @@ import (
 	dtoc "github.com/multiversx/mx-chain-simulator-go/pkg/dtos"
 )
 
+const errMsgAccountNotFound = "account was not found"
+
 type simulatorFacade struct {
 	simulator SimulatorHandler
 }
@@ -58,7 +60,8 @@ func (sf *simulatorFacade) SetStateMultipleOverwrite(stateSlice []*dtos.AddressS
 	}
 
 	err := sf.simulator.RemoveAccounts(accounts)
-	if err != nil {
+	shouldReturnErr := err != nil && !strings.Contains(err.Error(), errMsgAccountNotFound)
+	if shouldReturnErr {
 		return err
 	}
 
@@ -103,7 +106,7 @@ func (sf *simulatorFacade) GetObserversInfo() (map[uint32]*dtoc.ObserverInfo, er
 	for shardID, apiInterface := range restApiInterface {
 		split := strings.Split(apiInterface, ":")
 		if len(split) != 2 {
-			return nil, fmt.Errorf("cannot extrac port for shard ID=%d", shardID)
+			return nil, fmt.Errorf("cannot extract port for shard ID=%d", shardID)
 		}
 
 		port, err := strconv.Atoi(split[1])

--- a/pkg/facade/simulatorFacade_test.go
+++ b/pkg/facade/simulatorFacade_test.go
@@ -230,3 +230,24 @@ func TestSimulatorFacade_ForceUpdateValidatorStatistics(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, forceResetCalled)
 }
+
+func TestSimulatorFacade_GetObserversInfo(t *testing.T) {
+	t.Parallel()
+
+	simulator := &testscommon.SimulatorHandlerMock{
+		GetRestAPIInterfacesCalled: func() map[uint32]string {
+			return map[uint32]string{
+				0: ":1234",
+				1: "localhost:2233",
+			}
+		},
+	}
+
+	facade, _ := NewSimulatorFacade(simulator)
+	response, err := facade.GetObserversInfo()
+	require.NoError(t, err)
+	require.Equal(t, map[uint32]*dtoc.ObserverInfo{
+		0: {APIPort: 1234},
+		1: {APIPort: 2233},
+	}, response)
+}

--- a/pkg/proxy/api/endpoints.go
+++ b/pkg/proxy/api/endpoints.go
@@ -22,6 +22,7 @@ const (
 	setStateMultipleOverwriteEndpoint = "/simulator/set-state-overwrite"
 	addValidatorsKeys                 = "/simulator/add-keys"
 	forceUpdateValidatorStatistics    = "/simulator/force-reset-validator-statistics"
+	observersInfo                     = "/simulator/observers"
 )
 
 type endpointsProcessor struct {
@@ -50,6 +51,7 @@ func (ep *endpointsProcessor) ExtendProxyServer(httpServer *http.Server) error {
 	ws.POST(setStateMultipleOverwriteEndpoint, ep.setStateMultipleOverwrite)
 	ws.POST(addValidatorsKeys, ep.addValidatorKeys)
 	ws.POST(forceUpdateValidatorStatistics, ep.forceUpdateValidatorStatistics)
+	ws.GET(observersInfo, ep.getObserversInfo)
 
 	return nil
 }
@@ -96,6 +98,16 @@ func (ep *endpointsProcessor) generateBlocksUntilEpochReached(c *gin.Context) {
 	}
 
 	shared.RespondWith(c, http.StatusOK, gin.H{}, "", data.ReturnCodeSuccess)
+}
+
+func (ep *endpointsProcessor) getObserversInfo(c *gin.Context) {
+	observersData, err := ep.facade.GetObserversInfo()
+	if err != nil {
+		shared.RespondWithInternalError(c, errors.New("cannot get observers info"), err)
+		return
+	}
+
+	shared.RespondWith(c, http.StatusOK, observersData, "", data.ReturnCodeSuccess)
 }
 
 func (ep *endpointsProcessor) initialWallets(c *gin.Context) {

--- a/pkg/proxy/api/interface.go
+++ b/pkg/proxy/api/interface.go
@@ -15,5 +15,6 @@ type SimulatorFacade interface {
 	AddValidatorKeys(validators *dtosc.ValidatorKeys) error
 	GenerateBlocksUntilEpochIsReached(targetEpoch int32) error
 	ForceUpdateValidatorStatistics() error
+	GetObserversInfo() (map[uint32]*dtosc.ObserverInfo, error)
 	IsInterfaceNil() bool
 }

--- a/testscommon/simulatorHandlerMock.go
+++ b/testscommon/simulatorHandlerMock.go
@@ -12,6 +12,16 @@ type SimulatorHandlerMock struct {
 	GenerateBlocksUntilEpochIsReachedCalled  func(targetEpoch int32) error
 	ForceResetValidatorStatisticsCacheCalled func() error
 	RemoveAccountsCalled                     func(addresses []string) error
+	GetRestAPIInterfacesCalled               func() map[uint32]string
+}
+
+// GetRestAPIInterfaces -
+func (mock *SimulatorHandlerMock) GetRestAPIInterfaces() map[uint32]string {
+	if mock.GetRestAPIInterfacesCalled != nil {
+		return mock.GetRestAPIInterfacesCalled()
+	}
+
+	return nil
 }
 
 // RemoveAccounts -


### PR DESCRIPTION
- Added an extra endpoint `simulator/observers` that will return information about observers that are behind chain simulator
