### PR TITLE
make proxy pool enabled by default

### DIFF
--- a/pkg/proxy/configs/configs.go
+++ b/pkg/proxy/configs/configs.go
@@ -50,6 +50,7 @@ func CreateProxyConfigs(args ArgsProxyConfigs) (*ArgsOutputConfig, error) {
 		return nil, err
 	}
 
+	cfg.GeneralSettings.AllowEntireTxPoolFetch = true
 	cfg.GeneralSettings.ServerPort = args.ServerPort
 	cfg.Observers = make([]*data.NodeData, 0, len(args.RestApiInterfaces))
 	for shardID, nodeAPIInterface := range args.RestApiInterfaces {


### PR DESCRIPTION
Previously, the proxy's pool endpoint was disabled for chainsimulator, but it can be used in various instances and since it does not involve extra processing, we can simply enable it